### PR TITLE
Set HAProxy config location

### DIFF
--- a/haproxy18_cloud_init.yml
+++ b/haproxy18_cloud_init.yml
@@ -77,7 +77,9 @@ write_files:
             stop
           }
       path: /etc/rsyslog.d/99-haproxy18.conf
-
+    - content: |
+          CONFIG=/etc/haproxy18/haproxy18.cfg
+      path: /etc/sysconfig/haproxy18
 
 runcmd:
     - |


### PR DESCRIPTION
Previously HAProxy was reading /etc/haproxy18/haproxy18.cfg, which is the default config file.

[#176701089]



Authored-by: Patrick Oyarzun <poyarzun@pivotal.io>